### PR TITLE
Add support for client credentials flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ import { ApiProvider } from '@atlasconsulting/bedita-sdk';
 // used to register that specific client
 const client = ApiProvider.get('bedita', {
     baseUrl: 'https://api-bedita.example.com',
-    apiKey: '123456',
+    clientId: '123456',
+    clientSecret: 'abcdefg',
+    // apiKey: '123456', // as alternative you can use apiKey removing clientId and clientSecret (discouraged)
 });
 
 client.get('/documents')


### PR DESCRIPTION
This PR introduces support for client credentials flow instead of using API key that stays for backward compatibility.

```js
import { ApiProvider } from '@atlasconsulting/bedita-sdk';

const client = ApiProvider.get('bedita', {
    baseUrl: 'https://api-bedita.example.com',
    clientId: '123456',
    clientSecret: 'abcdefg',
});

const response = await client.get('/status');
```

In this case the `AuthInterceptor` will be responsible to retrieve the client access token before execute `GET /status` request.
Once obtained the access token it will be used as `Bearer` token in `Authorization` header and renewed when it expires.