### PR TITLE
Add option to include relationships getting authenticated user

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     ],
     "scripts": {
         "build": "./node_modules/.bin/tsc",
-        "test": "TS_NODE_COMPILER_OPTIONS='{ \"module\": \"commonjs\" }' mocha -r ts-node/register --require mock-local-storage --require tests/hooks.ts tests/**/*.test.ts",
+        "test": "TS_NODE_COMPILER_OPTIONS='{ \"module\": \"commonjs\" }' mocha -r ts-node/register --require mock-local-storage --require tests/hooks.ts \"tests/**/*.test.ts\"",
         "coverage": "c8 yarn run test",
         "lint": "eslint . --ext .ts",
         "prepare": "husky install"

--- a/src/bedita-api-client.ts
+++ b/src/bedita-api-client.ts
@@ -222,6 +222,20 @@ export class BEditaApiClient {
     }
 
     /**
+     * Say if interceptor is already present.
+     *
+     * @param interceptor The interceptor instance
+     */
+    public hasInterceptor(interceptor: RequestInterceptorInterface | ResponseInterceptorInterface): boolean {
+        const name = interceptor.constructor.name;
+        if ('requestHandler' in interceptor) {
+            return this.#requestInterceptorsMap.has(name);
+        }
+
+        return this.#responseInterceptorsMap.has(name);
+    }
+
+    /**
      * Remove an interceptor from axios instance.
      *
      * @param id The interceptor id
@@ -289,7 +303,9 @@ export class BEditaApiClient {
         const reqIntercetorsIds = [], respInterceptorsIds = [];
         if (config.requestInterceptors) {
             config.requestInterceptors.forEach(interceptorInstance => {
-                reqIntercetorsIds.push(this.addInterceptor(interceptorInstance));
+                if (!this.hasInterceptor(interceptorInstance)) {
+                    reqIntercetorsIds.push(this.addInterceptor(interceptorInstance));
+                }
             });
 
             delete config.requestInterceptors;
@@ -297,7 +313,9 @@ export class BEditaApiClient {
 
         if (config.responseInterceptors) {
             config.responseInterceptors.forEach(interceptorInstance => {
-                respInterceptorsIds.push(this.addInterceptor(interceptorInstance));
+                if (!this.hasInterceptor(interceptorInstance)) {
+                    respInterceptorsIds.push(this.addInterceptor(interceptorInstance));
+                }
             });
 
             delete config.responseInterceptors;

--- a/src/bedita-api-client.ts
+++ b/src/bedita-api-client.ts
@@ -422,6 +422,10 @@ export class BEditaApiClient {
     /**
      * Get the authenticated user and store it.
      * Format user data using `FormatUserInterceptor`.
+     * If `include` is passed than `MapIncludedInterceptor` will be used too
+     * to put related objects inside the relative relationship key.
+     *
+     * @param include A list of relationships to include
      */
     public async getUserAuth(include?: Array<string>): Promise<BEditaClientResponse<any>> {
         const responseInterceptors: Array<ResponseInterceptorInterface> = [new FormatUserInterceptor(this)];

--- a/src/bedita-api-client.ts
+++ b/src/bedita-api-client.ts
@@ -6,6 +6,7 @@ import FormatUserInterceptor from './interceptors/format-user.interceptor';
 import ContentTypeInterceptor from './interceptors/content-type-interceptor';
 import { RequestInterceptorInterface } from './interceptors/request-interceptor';
 import { ResponseInterceptorInterface } from './interceptors/response-interceptor';
+import MapIncludedInterceptor from './interceptors/map-included-interceptor';
 
 /**
  * Interface for API client configuration.
@@ -422,13 +423,18 @@ export class BEditaApiClient {
      * Get the authenticated user and store it.
      * Format user data using `FormatUserInterceptor`.
      */
-    public async getUserAuth(): Promise<BEditaClientResponse<any>> {
-        const response = await this.get(
-            '/auth/user',
-            {
-                responseInterceptors: [new FormatUserInterceptor(this)]
-            }
-        );
+    public async getUserAuth(include?: Array<string>): Promise<BEditaClientResponse<any>> {
+        const responseInterceptors: Array<ResponseInterceptorInterface> = [new FormatUserInterceptor(this)];
+        const params: any = {};
+        if (include && include.length > 0) {
+            responseInterceptors.unshift(new MapIncludedInterceptor());
+            params.include = include.join(',');
+        }
+
+        const response = await this.get('/auth/user', {
+            params,
+            responseInterceptors,
+        });
 
         this.#storageService.set('user', JSON.stringify(response.formattedData));
 

--- a/tests/bedita-api-client.test.ts
+++ b/tests/bedita-api-client.test.ts
@@ -62,6 +62,42 @@ describe('BEditaApiClient', function() {
         expect(other).equals(1);
     });
 
+    it('test hasInterceptor()', async function() {
+        const client = new BEditaApiClient({
+            baseUrl: 'https://example.com',
+            name: 'gustavo-api'
+        });
+
+        expect(client.hasInterceptor(new ContentTypeInterceptor(client))).to.be.true;
+        expect(client.hasInterceptor(new MapIncludedInterceptor())).to.be.false;
+
+        client.addInterceptor(new MapIncludedInterceptor());
+        expect(client.hasInterceptor(new MapIncludedInterceptor())).to.be.true;
+    });
+
+    it('test that adding missing interceptor in request then it has been removed', async function() {
+        const client = new BEditaApiClient({
+            baseUrl: this.apiConfig.baseURL,
+            apiKey: this.apiConfig.apiKey,
+        });
+
+        await client.get('/status', {responseInterceptors: [new MapIncludedInterceptor()]});
+        expect(client.hasInterceptor(new MapIncludedInterceptor())).to.be.false;
+    });
+
+    it('test that adding already present interceptor in request then it is still present', async function() {
+        const client = new BEditaApiClient({
+            baseUrl: this.apiConfig.baseURL,
+            apiKey: this.apiConfig.apiKey,
+        });
+
+        client.addInterceptor(new MapIncludedInterceptor());
+        expect(client.hasInterceptor(new MapIncludedInterceptor())).to.be.true;
+
+        await client.get('/status', {responseInterceptors: [new MapIncludedInterceptor()]});
+        expect(client.hasInterceptor(new MapIncludedInterceptor())).to.be.true;
+    });
+
     it('test getRequestInterceptorsMap()', function() {
         const client = new BEditaApiClient({
             baseUrl: 'https://example.com',

--- a/tests/bedita-api-client.test.ts
+++ b/tests/bedita-api-client.test.ts
@@ -75,7 +75,7 @@ describe('BEditaApiClient', function() {
         expect(client.hasInterceptor(new MapIncludedInterceptor())).to.be.true;
     });
 
-    it('test that adding missing interceptor in request then it has been removed', async function() {
+    it('test that adding missing interceptor in request then it will be removed', async function() {
         const client = new BEditaApiClient({
             baseUrl: this.apiConfig.baseURL,
             apiKey: this.apiConfig.apiKey,

--- a/tests/bedita-api-client.test.ts
+++ b/tests/bedita-api-client.test.ts
@@ -169,8 +169,21 @@ describe('BEditaApiClient', function() {
             await this.client.authenticate(this.apiConfig.adminUser, this.apiConfig.adminPwd);
             const response = await this.client.getUserAuth();
             expect(response.status).equals(200);
+            expect(response.formattedData.data.attributes.username).equals(this.apiConfig.adminUser);
+            expect(response.formattedData.roles?.[0]).equals('admin');
         } catch(e) {
             expect(false).equals(true); // this line should not be executed
+        }
+    });
+
+    it('test getUserAuth() with wrong included', async function() {
+        try {
+            await this.client.authenticate(this.apiConfig.adminUser, this.apiConfig.adminPwd);
+            await this.client.getUserAuth(['wrong', 'bad']);
+            expect(false).equals(true); // this line should not be executed
+        } catch(e) {
+            expect(e.request.path).equals('/auth/user?include=wrong,bad');
+            expect(e.response.status).equals(400);
         }
     });
 


### PR DESCRIPTION
This PR allows to include the objects related to authenticated user.

```js
const response = client.authenticate('user', 'pw')
    .then(r => client.getUserAuth(['rel_one', 'rel_two']));
    
console.log(response.formattedData); // will contain in `data.relationships.rel_one` and `data.relationships.rel_two` the objects related. 
```