### PR TITLE
Storage Adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,25 @@ client.addInterceptor(new MapIncludedInterceptor());
 A request interceptor **must** implements `RequestInterceptorInterface`.
 A response interceptor **must** implements `ResponseInterceptorInterface`.
 
+## Storage Adapters
+
+By default the JWT tokens are saved in `localStorage` but it is possibile to use a different adapter
+to store that data. There are two different adapters:
+
+* `LocalStorageAdaper`
+* `MemoryStorageAdapter` (to save only in memory)
+
+If you want to store data in a different storage you can implement a new adapter that must implement `StorageAdapterInterface`.
+
+```js
+const client = ApiProvider.get('bedita', {
+    baseUrl: 'https://api-bedita.example.com',
+    clientId: '123456',
+    clientSecret: 'abcdefg',
+    storageAdapter: new InnoDbAdapter(), // where class InnoDbAdapter implements StorageAdapterInterface
+});
+```
+
 ## Develop
 
 @todo

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,4 +9,6 @@ export { default as RefreshAuthInterceptor } from './interceptors/refresh-auth-i
 export { default as RequestInterceptor, RequestInterceptorInterface } from './interceptors/request-interceptor';
 export { default as ResponseInterceptor, ResponseInterceptorInterface } from './interceptors/response-interceptor';
 export { default as StorageService } from './services/storage-service';
+export { default as LocalStorageAdapter } from './services/adapters/local-storage-adapter';
+export { default as MemoryStorageAdapter } from './services/adapters/memory-storage-adapter';
 /* c8 ignore start */

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export { default as RefreshAuthInterceptor } from './interceptors/refresh-auth-i
 export { default as RequestInterceptor, RequestInterceptorInterface } from './interceptors/request-interceptor';
 export { default as ResponseInterceptor, ResponseInterceptorInterface } from './interceptors/response-interceptor';
 export { default as StorageService } from './services/storage-service';
+export { default as StorageAdapterInterface } from './services/adapters/storage-adapter-interface';
 export { default as LocalStorageAdapter } from './services/adapters/local-storage-adapter';
 export { default as MemoryStorageAdapter } from './services/adapters/memory-storage-adapter';
-/* c8 ignore start */
+/* c8 ignore stop */

--- a/src/interceptors/auth-interceptor.ts
+++ b/src/interceptors/auth-interceptor.ts
@@ -13,26 +13,26 @@ export default class AuthInterceptor extends RequestInterceptor {
      *
      * @param config The axios request config
      */
-    public requestHandler(config: AxiosRequestConfig): Promise<AxiosRequestConfig> {
-        config = this.setAuthorizationHeader(config);
+    public async requestHandler(config: AxiosRequestConfig): Promise<AxiosRequestConfig> {
+        config = await this.setAuthorizationHeader(config);
 
         // Authorization header set so go ahead
         if (config.headers?.Authorization) {
-            return Promise.resolve(config);
+            return config;
         }
 
         // trying client credentials auth so go ahead
         if (config.url === '/auth' && config.data?.grant_type === GrantType.ClientCredentials) {
-            return Promise.resolve(config);
+            return config;
         }
 
         if (!this.beditaClient.getConfig('clientId')) {
-            return Promise.resolve(config);
+            return config;
         }
 
-        return this.beditaClient
-            .clientCredentials()
-            .then(() => Promise.resolve(this.setAuthorizationHeader(config)));
+        await this.beditaClient.clientCredentials();
+
+        return await this.setAuthorizationHeader(config);
     }
 
     /**
@@ -40,8 +40,8 @@ export default class AuthInterceptor extends RequestInterceptor {
      *
      * @param config The axios request config
      */
-    protected setAuthorizationHeader(config: AxiosRequestConfig): AxiosRequestConfig {
-        const accessToken = this.beditaClient.getStorageService().accessToken;
+    protected async setAuthorizationHeader(config: AxiosRequestConfig): Promise<AxiosRequestConfig> {
+        const accessToken = await this.beditaClient.getStorageService().getAccessToken();
         if (accessToken && !config.headers?.Authorization) {
             config.headers.Authorization = `Bearer ${accessToken}`;
         }

--- a/src/interceptors/refresh-auth-interceptor.ts
+++ b/src/interceptors/refresh-auth-interceptor.ts
@@ -12,22 +12,22 @@ export default class RefreshAuthInterceptor extends ResponseInterceptor {
      *
      * @param error The original error.
      */
-    public errorHandler(error: any): Promise<any> {
+    public async errorHandler(error: any): Promise<any> {
         if (!error.response || !this.isTokenExpired(error.response)) {
             // Not an expired token's fault.
             if (error.response?.status === 401) { // if 401 clear tokens
                 const storage = this.beditaClient.getStorageService();
-                storage.clearTokens().remove('user');
+                await storage.clearTokens();
+                await storage.remove('user');
             }
 
             return Promise.reject(error);
         }
 
-        return this.beditaClient.renewTokens()
-            .then(() => {
-                delete error.config.headers.Authorization;
-                return this.beditaClient.request(error.config)
-            });
+        await this.beditaClient.renewTokens();
+        delete error.config.headers.Authorization;
+
+        return await this.beditaClient.request(error.config);
     }
 
     /**

--- a/src/services/adapters/local-storage-adapter.ts
+++ b/src/services/adapters/local-storage-adapter.ts
@@ -1,0 +1,38 @@
+import StorageAdapterInterface from "./storage-adapter-interface";
+
+/**
+ * Local Storage adapter
+ */
+export default class LocalStorageAdapter implements StorageAdapterInterface {
+    /**
+     * {@inheritdoc}
+     *
+     * @todo JSON parse if value a re json stringified
+     */
+    get(key: string): Promise<any> {
+        return Promise.resolve(localStorage.getItem(key));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @todo JSON stringify value that represents objects
+     */
+    set(key: string, value: any): Promise<any> {
+        return Promise.resolve(localStorage.setItem(key, value));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    remove(key: string): Promise<any> {
+        return Promise.resolve(localStorage.removeItem(key));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    empty(): Promise<any>  {
+        return Promise.resolve(localStorage.clear());
+    }
+}

--- a/src/services/adapters/memory-storage-adapter.ts
+++ b/src/services/adapters/memory-storage-adapter.ts
@@ -1,0 +1,45 @@
+import StorageAdapterInterface from "./storage-adapter-interface";
+
+/**
+ * In memory storage adapter.
+ */
+export default class MemoryStorageAdapter implements StorageAdapterInterface {
+    /**
+     * The memory store
+     */
+    #store: { [s: string]: any } = {};
+
+    /**
+     * @inheritdoc
+     */
+    get(key: string): Promise<any> {
+        return Promise.resolve(this.#store?.[key]);
+    }
+
+    /**
+    * @inheritdoc
+    */
+    set(key: string, value: any): Promise<any> {
+        this.#store[key] = value;
+
+        return Promise.resolve();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    remove(key: string): Promise<any> {
+        delete this.#store[key];
+
+        return Promise.resolve();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    empty(): Promise<any> {
+        this.#store = {};
+
+        return Promise.resolve();
+    }
+}

--- a/src/services/adapters/storage-adapter-interface.ts
+++ b/src/services/adapters/storage-adapter-interface.ts
@@ -1,3 +1,4 @@
+/* c8 ignore start */
 /**
  * Storage service interface.
  */
@@ -28,3 +29,4 @@ export default interface StorageAdapterInterface {
      */
     empty(): Promise<boolean>;
 }
+/* c8 ignore stop */

--- a/src/services/adapters/storage-adapter-interface.ts
+++ b/src/services/adapters/storage-adapter-interface.ts
@@ -1,0 +1,30 @@
+/**
+ * Storage service interface.
+ */
+export default interface StorageAdapterInterface {
+    /**
+     * Get the storaged value.
+     */
+    get(key: string): Promise<any>;
+
+    /**
+     * Set a value in the storage.
+     * Return this for chainability.
+     *
+     * @param key The starage key
+     * @param value The value
+     */
+    set(key: string, value: any): Promise<any>;
+
+    /**
+     * Remove a key from the storage.
+     *
+     * @param key The key to remove
+     */
+    remove(key: string): Promise<any>;
+
+    /**
+     * Clear the storage.
+     */
+    empty(): Promise<boolean>;
+}

--- a/tests/bedita-api-client.test.ts
+++ b/tests/bedita-api-client.test.ts
@@ -177,15 +177,15 @@ describe('BEditaApiClient', function() {
     it('test renewTokens()', async function() {
         // 200 Ok
         await this.client.authenticate(this.apiConfig.adminUser, this.apiConfig.adminPwd);
-        this.client.getStorageService().accessToken = null;
-        const prevRefreshToken = this.client.getStorageService().refreshToken;
+        await this.client.getStorageService().setAccessToken(null);
+        const prevRefreshToken = await this.client.getStorageService().getRefreshToken();
         const response = await this.client.renewTokens();
         expect(response.status).equals(200);
-        expect(this.client.getStorageService().accessToken).is.not.empty;
+        expect(await this.client.getStorageService().getAccessToken()).is.not.empty;
 
         // Missing refresh token
         try {
-            this.client.getStorageService().refreshToken = '';
+            await this.client.getStorageService().setRefreshToken('');
             await this.client.renewTokens();
             expect(false).equals(true); // this line should not be executed
         } catch(message) {
@@ -193,7 +193,7 @@ describe('BEditaApiClient', function() {
         }
         // 401 Unauthorized
         try {
-            this.client.getStorageService().refreshToken = '123456';
+            await this.client.getStorageService().setRefreshToken('123456');
             await this.client.renewTokens();
             expect(false).equals(true); // this line should not be executed
         } catch(resp) {

--- a/tests/services/adapters/local-storage-adapter.test.ts
+++ b/tests/services/adapters/local-storage-adapter.test.ts
@@ -1,0 +1,24 @@
+import { expect } from 'chai';
+import LocalStorageAdapter from '../../../src/services/adapters/local-storage-adapter';
+
+describe('LocalStorageAdapter', function() {
+
+    beforeEach(function() {
+        localStorage.clear();
+
+        this.adapter = new LocalStorageAdapter();
+    });
+
+    it('test get(), set(), remove()', async function() {
+        await this.adapter.set('keyOne', 'hello');
+
+        expect(localStorage.getItem('keyOne')).equals('hello');
+        expect(await this.adapter.get('keyOne')).equals('hello');
+        expect(await this.adapter.get('InvalidKey')).is.null;
+
+        await this.adapter.remove('keyOne');
+        expect(localStorage.getItem('keyOne')).is.null;
+        expect(await this.adapter.get('keyOne')).is.null;
+    });
+
+});

--- a/tests/services/adapters/memory-storage-adapter.test.ts
+++ b/tests/services/adapters/memory-storage-adapter.test.ts
@@ -1,0 +1,32 @@
+import { expect } from 'chai';
+import MemoryStorageAdapter from '../../../src/services/adapters/memory-storage-adapter';
+
+describe('MemoryStorageAdapter', function() {
+
+    beforeEach(function() {
+        this.adapter = new MemoryStorageAdapter();
+    });
+
+    it('test get(), set(), remove()', async function() {
+        await this.adapter.set('keyOne', 'hello');
+
+        expect(await this.adapter.get('keyOne')).equals('hello');
+        expect(await this.adapter.get('InvalidKey')).is.undefined;
+
+        await this.adapter.remove('keyOne');
+        expect(await this.adapter.get('keyOne')).is.undefined;
+    });
+
+    it ('test clear()', async function() {
+        await this.adapter.set('one', 'hello');
+        await this.adapter.set('two', 'world');
+
+        expect(await this.adapter.get('one')).equals('hello');
+        expect(await this.adapter.get('two')).equals('world');
+
+        await this.adapter.empty();
+        expect(await this.adapter.get('one')).is.undefined;
+        expect(await this.adapter.get('two')).is.undefined;
+    });
+
+});

--- a/tests/services/storage-service.test.ts
+++ b/tests/services/storage-service.test.ts
@@ -1,0 +1,39 @@
+import { expect } from 'chai';
+import { LocalStorageAdapter } from '../../src';
+import StorageService from '../../src/services/storage-service';
+
+describe('StorageService', function() {
+
+    beforeEach(function() {
+        localStorage.clear();
+    });
+
+    it('test get(), set(), remove()', async function() {
+        let service = new StorageService('bedita', new LocalStorageAdapter());
+        await service.set('one', 'hello');
+        expect(await service.get('one')).equals(localStorage.getItem('bedita.one'));
+
+        await service.remove('one');
+        expect(await service.get('one')).to.be.null;
+    });
+
+    it('test change namespace delimiter', async function() {
+        let service = new StorageService('bedita', new LocalStorageAdapter());
+        service.setNamespaceSeparator('_');
+        await service.set('one', 'hello');
+        expect(await service.get('one')).equals(localStorage.getItem('bedita_one'));
+    });
+
+    it('test set, get and clear tokens', async function() {
+        let service = new StorageService('bedita', new LocalStorageAdapter());
+        await service.setAccessToken('xyz');
+        await service.setRefreshToken('abc');
+        expect(await service.getAccessToken()).equals(localStorage.getItem('bedita.access_token'));
+        expect(await service.getRefreshToken()).equals(localStorage.getItem('bedita.refresh_token'));
+
+        await service.clearTokens();
+        expect(await service.getAccessToken()).to.be.null;
+        expect(await service.getRefreshToken()).to.be.null;
+    });
+
+});


### PR DESCRIPTION
With this PR the place where JWTs are storaged can be determinated using storage adapters.
Storage adapters **must** implement `StorageAdapterInterface`. 

There are two adapters already implemented, `LocalStorageAdapter` and `MemoryStorageAdapter` and by default `LocalStorageAdapter` is used.

Other adapters can be implemented and used in the client

```js
const client = ApiProvider.get('bedita', {
    baseUrl: 'https://api-bedita.example.com',
    clientId: '123456',
    clientSecret: 'abcdefg',
    storageAdapter: new InnoDbAdapter(), // where class InnoDbAdapter implements StorageAdapterInterface
});
```

The `StorageAdapterInterface` defines async methods using `Promise` to better adapt to any storage used.