### PR TITLE
Add ApiProvider.has() method

### DIFF
--- a/src/api-provider.ts
+++ b/src/api-provider.ts
@@ -19,7 +19,7 @@ export default class ApiProvider {
      * @param config The configuration to use for create new client.
      */
     public static get(name: string, config?: ApiClientConfig): BEditaApiClient {
-        if (this.#registry[name]) {
+        if (this.has(name)) {
             return this.#registry[name];
         }
 
@@ -31,6 +31,19 @@ export default class ApiProvider {
         this.#registry[name] = new BEditaApiClient(config);
 
         return this.#registry[name];
+    }
+
+    /**
+     * Return `true` if an API client with that `name` is in the registry.
+     *
+     * @param name  The name of registered API client
+     */
+    public static has(name: string): boolean {
+        if (this.#registry[name]) {
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/tests/api-provider.test.ts
+++ b/tests/api-provider.test.ts
@@ -27,4 +27,12 @@ describe('ApiProvider', function() {
         ApiProvider.remove('whatever'); // do nothing
         expect('https://example.com').to.equal(client.getConfig('baseUrl'));
     });
+
+    it('check if api client is in the registry', function() {
+        expect(ApiProvider.has('anotherApi')).to.be.false;
+        ApiProvider.get('anotherApi', { baseUrl: 'https://example.com'});
+        expect(ApiProvider.has('anotherApi')).to.be.true;
+        ApiProvider.remove('anotherApi');
+        expect(ApiProvider.has('anotherApi')).to.be.false;
+    });
 });


### PR DESCRIPTION
This PR add a method to know if a client with a certain name is already in the registry of `ApiProvider`. 