### PR TITLE
Remove link interceptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ A set of default interceptor are always used:
 * `ContentTypeInterceptor` set default content type if no one is passed
 * `RefreshAuthInterceptor` is responsible for refreshing the access token when expired
 
+Other optional interceptor that can be used are:
+
+* `RemoveLinksInterceptor` remove the `links` attribute from the response
+* `MapIncludedInterceptor` embed `included` resource inside the related `relationships` attribute
+
 An interceptor can be added to the client or to a request.
 When added to the client it will be used unless it was removed.
 

--- a/src/interceptors/remove-links-interceptor.ts
+++ b/src/interceptors/remove-links-interceptor.ts
@@ -1,0 +1,42 @@
+import { AxiosResponse } from "axios";
+import ResponseInterceptor from "./response-interceptor";
+import { BEditaClientResponse, JsonApiResourceObject } from "../bedita-api-client";
+
+
+/**
+ * Remove links attribute from JSON API response.
+ */
+export class RemoveLinksInterceptor extends ResponseInterceptor {
+
+    /**
+     * Remove links from JSON API response.
+     *
+     * @param response The response.
+     */
+    public responseHandler(response: AxiosResponse): Promise<BEditaClientResponse<any> | AxiosResponse<any>> {
+        delete response.data?.links;
+        delete response.data?.meta?.schema;
+        response.data.data = this.removeLinks(response.data.data);
+
+        return Promise.resolve(response);
+    }
+
+    /**
+     * Remove links from JSON API resource object.
+     *
+     * @param data The resource object.
+     */
+    protected removeLinks(data: JsonApiResourceObject|JsonApiResourceObject[]): JsonApiResourceObject|JsonApiResourceObject[] {
+        if (Array.isArray(data)) {
+            return data.map((d) => this.removeLinks(d)) as JsonApiResourceObject[];
+        }
+
+        delete data?.links;
+
+        Object.keys(data?.relationships || []).forEach((rel) => {
+            delete data?.relationships[rel]?.links;
+        });
+
+        return data;
+    }
+}

--- a/tests/interceptors/remove-links-interceptor.test.ts
+++ b/tests/interceptors/remove-links-interceptor.test.ts
@@ -1,0 +1,74 @@
+import { AxiosResponse, AxiosHeaders } from 'axios';
+import { expect } from 'chai';
+import { RemoveLinksInterceptor } from '../../src/interceptors/remove-links-interceptor';
+import { BEditaApiClient, JsonApiResourceObject } from '../../src/bedita-api-client';
+
+describe('RemoveLinksInterceptor', function() {
+
+    it('test that links are removed from response', async function() {
+        const client = new BEditaApiClient({ baseUrl: 'https://example.com'});
+        const interceptor = new RemoveLinksInterceptor(client);
+        const initialResponse: AxiosResponse = {
+            status: 200,
+            statusText: 'ok',
+            headers: {},
+            config: {
+                headers: new AxiosHeaders({ 'Content-Type': 'application/json' }),
+            },
+            data: {
+                data: [
+                    {
+                        id: 1,
+                        type: 'users',
+                        attributes: {
+                            title: 'User number one',
+                        },
+                        links: {
+                            self: 'https://api.example.com/users/1',
+                        },
+                        relationships: {
+                            attach: {
+                                links: {
+                                    related: 'https://api.example.com/users/1/attach',
+                                    self: 'https://api.example.com/users/1/relationships/attach',
+                                },
+                            },
+                            poster: {
+                                links: {
+                                    related: 'https://api.example.com/users/1/poster',
+                                    self: 'https://api.example.com/users/1/relationships/poster',
+                                },
+                            },
+                        },
+                    },
+                ],
+                links: {
+                    self: 'https://api.example.com/users',
+                    home: 'https://api.example.com/home',
+                    first: 'https://api.example.com/users',
+                    last: 'https://api.example.com/users?page=32',
+                    prev: null,
+                    next: 'https://api.example.com/users?page=2',
+                },
+                meta: {
+                    schema: {
+                        users: {
+                            $id: 'https://api.example.com/model/schema/users',
+                            revision: '123456789',
+                        },
+                    },
+                }
+            },
+        };
+
+        const response = await interceptor.responseHandler(initialResponse);
+        expect(response.data).to.not.have.property('links');
+        expect(response.data.meta).to.not.have.property('schema');
+
+        response.data.data.forEach((d: JsonApiResourceObject) => {
+            expect(d).to.not.have.property('links');
+            expect(d?.relationships?.attach).to.not.have.property('links');
+            expect(d?.relationships?.poster).to.not.have.property('links');
+        });
+    });
+});


### PR DESCRIPTION
This PR adds an interceptor useful if you want to remove `links` attribute from JSON API response.